### PR TITLE
Remove the Buy button in the Tour page

### DIFF
--- a/src/tours/Tour.js
+++ b/src/tours/Tour.js
@@ -34,6 +34,7 @@ const useStyles = makeStyles({
     },
     content: {
         position: 'relative',
+        minHeight: 125,
     },
     newIcon: {
         position: 'absolute',


### PR DESCRIPTION
[Trello Card #289](https://trello.com/c/Rb8nQi2d/289-remove-buy-button-from-tours-in-demo)

The Buy button leads to a broken page, and we don't sell the modules one by one. So it's better to remove it from the Tour page.

## Todo

- [x] Remove the Buy button
- [x] Remove the extra label "comment"
- [x] Align all the Play buttons

## Release process

- [x] Select a Github label (**WIP** or **RFR**)

## Screenshot(s)

![Sélection_010](https://user-images.githubusercontent.com/5584839/95745088-c1bcc880-0c94-11eb-809e-9ba7ebd41bcd.png)
