### PR TITLE
Fix the Breadcrumb not accessible on some List pages

### DIFF
--- a/src/layout/Breadcrumb.tsx
+++ b/src/layout/Breadcrumb.tsx
@@ -130,6 +130,10 @@ const useStyles = makeStyles(theme => ({
     root: {
         paddingTop: theme.spacing(1),
         fontSize: 'small',
+        // Display the Breadcrumb over the custom Layout of some pages by adding a zIndex and a maxWidth
+        // @see "src/products/ProductList.tsx" or "src/visitors/VisitorList.tsx"
+        maxWidth: '400px',
+        zIndex: 1,
         '& a': {
             pointerEvents: 'visible',
         },


### PR DESCRIPTION
[Trello Card #291](https://trello.com/c/knixPcjX/291-we-cant-go-to-the-dashboard-from-breadcrumb-in-demo) - 

The Breadcrumb is masked by the negative margin of some List pages. So I display it over the Layout by using a `zIndex`.

It's not an optimal solution, but as we should start working on redesigning the layout, I prefer not to spend too much time.

## Todo

- [x] Change the Breadcrumb style to display it over the Layout

## Release process

- [x] Select a Github label (**WIP** or **RFR**)

## Screenshot(s)

![Sélection_007](https://user-images.githubusercontent.com/5584839/95972512-d3c47580-0e12-11eb-9739-d3987fbe5553.png)
