### PR TITLE
Disable the Back Button in the ra-realtime tour

### DIFF
--- a/src/tours/tours.ts
+++ b/src/tours/tours.ts
@@ -235,9 +235,12 @@ const tours: { [id: string]: TourType } = {
                     );
                     await timeout(1500); // would be so awesome if redirect was awaitable!
                 },
-                disableBeacon: true,
                 target: '[data-testid="commands-menu"]',
                 content: "Seems like you just had new orders, let's check...",
+                disableBeacon: true,
+                joyrideProps: {
+                    hideBackButton: true,
+                },
                 after: async ({ redirect }) => {
                     localStorage.setItem('batchLevel', '1');
                     await timeout(500);
@@ -247,6 +250,9 @@ const tours: { [id: string]: TourType } = {
             {
                 target: '[data-testid=order-ordered-datagrid]',
                 content: 'Your new orders can stand-out from others',
+                joyrideProps: {
+                    hideBackButton: true,
+                },
             },
             {
                 before: async ({ dataProvider }) => {
@@ -279,6 +285,9 @@ const tours: { [id: string]: TourType } = {
                 target: '[data-testid=order-ordered-datagrid]',
                 content:
                     "And newest orders even appear while you're on the page",
+                joyrideProps: {
+                    hideBackButton: true,
+                },
                 after: async ({ dataProvider, dispatch, redirect }) => {
                     // Generate a lock on Products #1, #2 and #5
                     await Promise.all(
@@ -351,6 +360,9 @@ const tours: { [id: string]: TourType } = {
                 target: '[data-testid=productlocktile]',
                 content:
                     'You can lock resources in realtime (this one will be unlocked in a few seconds)',
+                joyrideProps: {
+                    hideBackButton: true,
+                },
                 after: async ({ dataProvider, dispatch, refresh }) => {
                     // Reset the locks on Products #2 and #5
                     // The lock on Procuct #1 has been deleted during the scenario


### PR DESCRIPTION
[Trello Card #290](https://trello.com/c/xVgZzhdF/290-fix-ra-realtime-tour)

The ra-realtime tour crashes when doing the following steps:

> Quite tricky :
> - tours > launch realtime
> - next > next > back : tour "crashes"
> - tours > launch realtime
> - next : incorrect data state

## Todo

- [x] Disable the back button in all steps of the ra-realtime tour

## Release process

- [x] Select a Github label (**WIP** or **RFR**)

## Screenshot(s)

![Sélection_012](https://user-images.githubusercontent.com/5584839/96129479-f6c85580-0ef6-11eb-880c-58b8be0cb6c4.png)

