### PR TITLE
Fix ra-preference tour entering in an endless loop when accessing its direct url

### DIFF
--- a/src/tours/TourLauncher.tsx
+++ b/src/tours/TourLauncher.tsx
@@ -1,5 +1,5 @@
-import { FC, useEffect } from 'react';
-import { useParams } from 'react-router';
+import React, { FC, useEffect } from 'react';
+import { Redirect, useParams } from 'react-router';
 import { useTour } from '@react-admin/ra-tour';
 
 const TourLauncher: FC = () => {
@@ -13,7 +13,7 @@ const TourLauncher: FC = () => {
         }
     });
 
-    return null;
+    return running ? <Redirect to="/" /> : null;
 };
 
 export default TourLauncher;


### PR DESCRIPTION
[Trello Card #301](https://trello.com/c/QtGlUJyK/301-ra-preference-tour-enters-in-an-endless-loop-when-accessing-its-direct-url)

## Todo

- [x] Prevent the endless loop
- [x] Redirect right after starting the tour to no been stuck on the wrong page

## Release process

- [x] Select a Github label (**WIP** or **RFR**)

## Screenshot(s)

**Before**

![Peek 19-10-2020 11-19](https://user-images.githubusercontent.com/5584839/96426648-cede3800-11fd-11eb-89f3-1d31f41a7072.gif)

**After**

![Peek 19-10-2020 11-20](https://user-images.githubusercontent.com/5584839/96426656-d271bf00-11fd-11eb-9656-d4b9ee9f099b.gif)


