### PR TITLE
Fix clicking on breadcrumb item "Review" does nothing

### DIFF
--- a/src/layout/Breadcrumb.tsx
+++ b/src/layout/Breadcrumb.tsx
@@ -54,7 +54,7 @@ const CustomBreadcrumb: FC = props => {
             <BreadcrumbItem
                 name="reviews"
                 label={translate('resources.reviews.name', 2)}
-                to="/reviews"
+                to="/reviews?filter={}"
             >
                 <BreadcrumbItem
                     name="status_filter"


### PR DESCRIPTION
[Trello Card #308](https://trello.com/c/V0I6NHHw/308-clicking-on-breadcrumb-item-review-does-nothing)

If we access directly to the page `/reviews`, the filters will be guessed from redux. We need to pass an empty object to clear the filters.

## Todo

- [x] Clear the filters for the reviews' breadcrumb

## Release process

- [x] Select a Github label (**WIP** or **RFR**)

## Screenshot(s)

![Peek 20-10-2020 10-37](https://user-images.githubusercontent.com/5584839/96562283-e0d4df00-12c0-11eb-8143-ff8504d0c7b9.gif)