### PR TITLE
Widen the breadcrumb to work in all scenarios

### DIFF
--- a/src/layout/Breadcrumb.tsx
+++ b/src/layout/Breadcrumb.tsx
@@ -132,7 +132,7 @@ const useStyles = makeStyles(theme => ({
         fontSize: 'small',
         // Display the Breadcrumb over the custom Layout of some pages by adding a zIndex and a maxWidth
         // @see "src/products/ProductList.tsx" or "src/visitors/VisitorList.tsx"
-        maxWidth: '400px',
+        maxWidth: '700px',
         zIndex: 1,
         '& a': {
             pointerEvents: 'visible',


### PR DESCRIPTION
[Trello Card #312](https://trello.com/c/Wf6x6iYK/312-breadcrumb-is-cut-in-demo) - Breadcrumb is cut in demo

To avoid any conflict with the filters, we do not display the breadcrumb on the entire page. But the allowed width is not large enough to work in all scenarios. That's why I'm widening it.

## Todo

- [x] Widen the breadcrumb

## Release process

- [x] Select a Github label (**WIP** or **RFR**)

## Screenshot(s)

![Sélection_009](https://user-images.githubusercontent.com/5584839/96846920-d5192200-1452-11eb-88da-ef9818762e15.png)